### PR TITLE
add aql endpoint with builder

### DIFF
--- a/lib/artifactory.rb
+++ b/lib/artifactory.rb
@@ -23,6 +23,7 @@ module Artifactory
   autoload :Defaults,     "artifactory/defaults"
   autoload :Error,        "artifactory/errors"
   autoload :Util,         "artifactory/util"
+  autoload :AQL,         "artifactory/aql"
 
   module Collection
     autoload :Artifact, "artifactory/collections/artifact"

--- a/lib/artifactory/aql.rb
+++ b/lib/artifactory/aql.rb
@@ -44,14 +44,21 @@ module Artifactory
     class CompoundCriteria
       attr_accessor :criterias, :op
 
-      def initialize
-        # https://www.jfrog.com/confluence/display/JFROG/Artifactory+Query+Language#ArtifactoryQueryLanguage-ComparisonOperators
-        @op = :and # also takes :or
-        @criterias = []
+      def initialize(op, c)
+        # https://www.jfrog.com/confluence/display/JFROG/Artifactory+Query+Language#ArtifactoryQueryLanguage-CompoundingCriteria
+        @op = op
+        @criterias = c
       end
 
       def build
-        ""
+        case @op
+          when :and
+            "{\"@" + @field + ":{\"$eq:\"" + @value +"\"}}"
+          when :or
+            "{\"@" + @field + ":{\"$ne:\"" + @value +"\"}}"
+          else
+            raise "Invalid operator"
+        end
       end
     end
 
@@ -67,8 +74,8 @@ module Artifactory
         @criterias << Criteria.new(f, op, v)
       end
 
-      def with_compound_criteria(c)
-        @criterias << criteria
+      def with_compound_criteria((op, c))
+        @criterias << CompoundCriteria.new(op, c)
       end
 
       def process_criteria(c)

--- a/lib/artifactory/aql.rb
+++ b/lib/artifactory/aql.rb
@@ -1,0 +1,90 @@
+#
+# Copyright 2014-2018 Chef Software, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+module Artifactory
+  module AQL
+    # https://www.jfrog.com/confluence/display/JFROG/Artifactory+Query+Language#ArtifactoryQueryLanguage-FieldCriteria
+    class Criteria
+      attr_accessor :field, :op, :value
+
+      def initialize(field, op, value)
+        # https://www.jfrog.com/confluence/display/JFROG/Artifactory+Query+Language#ArtifactoryQueryLanguage-SupportedDomains
+        @field = field
+        # https://www.jfrog.com/confluence/display/JFROG/Artifactory+Query+Language#ArtifactoryQueryLanguage-ComparisonOperators
+        @op = op # also takes :not_equals
+        @value = value
+      end
+
+      def build
+        case @op
+          when :equals
+            "{\"@" + @field + ":{\"$eq:\"" + @value +"\"}}"
+          when :not_equals
+            "{\"@" + @field + ":{\"$ne:\"" + @value +"\"}}"
+          else
+            raise "Invalid operator"
+        end
+      end
+    end
+
+    # https://www.jfrog.com/confluence/display/JFROG/Artifactory+Query+Language#ArtifactoryQueryLanguage-CompoundingCriteria
+    class CompoundCriteria
+      attr_accessor :criterias, :op
+
+      def initialize
+        # https://www.jfrog.com/confluence/display/JFROG/Artifactory+Query+Language#ArtifactoryQueryLanguage-ComparisonOperators
+        @op = :and # also takes :or
+        @criterias = []
+      end
+
+      def build
+        ""
+      end
+    end
+
+    class ItemQueryBuilder
+      attr_accessor :type, :query
+
+      def initialize
+        @criterias = []
+        @query = "items.find("
+      end
+
+      def with_criteria(f, op, v)
+        @criterias << Criteria.new(f, op, v)
+      end
+
+      def with_compound_criteria(c)
+        @criterias << criteria
+      end
+
+      def process_criteria(c)
+        @query += c.build
+        @query += ")"
+      end
+
+      def build
+        @criterias.each { |c| process_criteria(c) }
+        @query
+      end
+
+      def query
+        raise 'No criteria added' if @criterias.length() == 0
+        build
+      end
+    end
+  end
+end

--- a/lib/artifactory/resources/artifact.rb
+++ b/lib/artifactory/resources/artifact.rb
@@ -53,6 +53,50 @@ module Artifactory
       end
 
       #
+      # Search for an artifact using AQL:
+      #
+      # @example Search for all repositories with the given gavc
+      #   Artifact.aql_search(
+      #     group:      'org.acme',
+      #     name:       'artifact',
+      #     version:    '1.0',
+      #     classifier: 'sources',
+      #   )
+      #
+      # @example Search for all artifacts with the given gavc in a specific repo
+      #   Artifact.aql_search(
+      #     group:      'org.acme',
+      #     name:       'artifact',
+      #     version:    '1.0',
+      #     classifier: 'sources',
+      #     repos:      'libs-release-local',
+      #   )
+      #
+      # @param [Hash] options
+      #   the list of options to search with
+      # @option options [Artifactory::Client] :client
+      #   the client object to make the request with
+      # @option options [String] :aql
+      #   an AQL object to search with https://www.jfrog.com/confluence/display/JFROG/Artifactory+Query+Language
+      #
+      # @return [Array<Resource::Artifact>]
+      #   a list of artifacts that match the query
+      #
+      def aql_search(options = {})
+        client = extract_client!(options)
+        params = Util.slice(options, :aql)
+        headers ||= {
+          "Content-Type" => "plain/text",
+        }
+
+        client.post("/api/search/aql", params, headers)["results"].map do |artifact|
+          puts artifact.inspect
+          # /api/storage/libs-properties-local/org/acme/artifact.deb
+          from_url("/api/storage/" + artifact['repo'] + "/" + artifact['path'] + "/" + artifact['name'], client: client)
+        end
+      end
+
+      #
       # Search for an artifact by Maven coordinates: +Group ID+, +Artifact ID+,
       # +Version+ and +Classifier+.
       #

--- a/lib/artifactory/resources/artifact.rb
+++ b/lib/artifactory/resources/artifact.rb
@@ -61,9 +61,10 @@ module Artifactory
       #   )
       #
       # @example Search for all artifacts in a specific repos using the builder
-      #   aql_query = AQLBuilder.Artifact.with_repos([repos]).with_properties([environment: dev]).build
+      #   AQL = ItemQueryBuilder.new
+      #   AQL.with_criteria(["@build.name", :eq, "artifactory"])
       #   Artifact.aql_search(
-      #     aql:      aql
+      #     aql:      aql.query
       #   )
       #
       # @param [Hash] options

--- a/lib/artifactory/resources/artifact.rb
+++ b/lib/artifactory/resources/artifact.rb
@@ -55,21 +55,15 @@ module Artifactory
       #
       # Search for an artifact using AQL:
       #
-      # @example Search for all repositories with the given gavc
+      # @example Search for all artifacts in specific repos with string
       #   Artifact.aql_search(
-      #     group:      'org.acme',
-      #     name:       'artifact',
-      #     version:    '1.0',
-      #     classifier: 'sources',
+      #     aql: "items.find({\"@repo\":{\"$eq\":\"libs-releases-local\"}})"
       #   )
       #
-      # @example Search for all artifacts with the given gavc in a specific repo
+      # @example Search for all artifacts in a specific repos using the builder
+      #   aql_query = AQLBuilder.Artifact.with_repos([repos]).with_properties([environment: dev]).build
       #   Artifact.aql_search(
-      #     group:      'org.acme',
-      #     name:       'artifact',
-      #     version:    '1.0',
-      #     classifier: 'sources',
-      #     repos:      'libs-release-local',
+      #     aql:      aql
       #   )
       #
       # @param [Hash] options
@@ -90,8 +84,6 @@ module Artifactory
         }
 
         client.post("/api/search/aql", params, headers)["results"].map do |artifact|
-          puts artifact.inspect
-          # /api/storage/libs-properties-local/org/acme/artifact.deb
           from_url("/api/storage/" + artifact['repo'] + "/" + artifact['path'] + "/" + artifact['name'], client: client)
         end
       end

--- a/spec/integration/resources/artifact_spec.rb
+++ b/spec/integration/resources/artifact_spec.rb
@@ -50,6 +50,22 @@ module Artifactory
       it_behaves_like "an artifact search endpoint", :search, name: "artifact.deb"
     end
 
+    describe ".aql_search" do
+      let(:artifacts) do
+        artifacts = described_class.send(:aql_search, aql: "items.find({\"@build.name\":{\"$eq\":\"artifactory\"}})")
+      end
+
+      it "returns a downloadable artifact" do
+        expect(artifacts).to be_a(Array)
+        expect(artifacts.size).to eq(1)
+
+        artifact = artifacts.first
+        expect(artifact).to be_a(described_class)
+        expect(artifact.repo).to eq("libs-release-local")
+        expect(artifact.download_uri).to be_truthy
+      end
+    end
+
     describe ".gavc_search" do
       it_behaves_like "an artifact search endpoint", :gavc_search, {
         group:      "org.acme",

--- a/spec/support/api_server/artifact_endpoints.rb
+++ b/spec/support/api_server/artifact_endpoints.rb
@@ -10,6 +10,31 @@ module Artifactory
         end
       end
 
+      app.post("/api/search/aql") do
+        content_type "application/json"
+        JSON.fast_generate({
+          "results" => [
+            {
+              "repo" => "libs-release-local",
+              "path" => "org/jfrog/artifactory",
+              "name" => "artifactory.war",
+              "type" => "item type",
+              "size" => "75500000",
+              "created" => "2015-01-01T10:10;10",
+              "created_by" => "Jfrog",
+              "modified" => "2015-01-01T10:10;10",
+              "modified_by" => "Jfrog",
+              "updated" => "2015-01-01T10:10;10"
+            },
+          ],
+          "range" => {
+            "start_pos" => 0,
+            "end_pos" => 1,
+            "total" => 1
+          }
+        })
+      end
+
       app.get("/api/search/gavc") do
         content_type "application/vnd.org.jfrog.artifactory.search.GavcSearchResult+json"
         artifacts_for_conditions do
@@ -87,6 +112,32 @@ module Artifactory
           }
         )
       end
+
+      app.get("/api/storage/libs-release-local/org/jfrog/artifactory/artifactory.war") do
+        content_type "application/vnd.org.jfrog.artifactory.storage.FileInfo+json"
+        JSON.fast_generate(
+          "uri"          => server_url.join("/api/storage/libs-release-local/org/acme/artifact.deb"),
+          "downloadUri"  => server_url.join("/artifactory/libs-release-local/org/acme/artifact.deb"),
+          "repo"         => "libs-release-local",
+          "path"         => "/org/jfrog/artifactory/artifactory.war",
+          "created"      => Time.parse("1991-07-23 12:07am"),
+          "createdBy"    => "schisamo",
+          "lastModified" => Time.parse("2013-12-24 11:50pm"),
+          "modifiedBy"   => "sethvargo",
+          "lastUpdated"  => Time.parse("2014-01-01 1:00pm"),
+          "size"         => "1024",
+          "mimeType"     => "application/tgz",
+          "checksums"    => {
+            "md5" => "MD5123",
+            "sha" => "SHA456",
+          },
+          "originalChecksums" => {
+            "md5" => "MD5123",
+            "sha" => "SHA456",
+          }
+        )
+      end
+
 
       app.get("/api/storage/libs-properties-local/org/acme/artifact.deb") do
         content_type "application/vnd.org.jfrog.artifactory.storage.ItemProperties+json"

--- a/spec/unit/aql_spec.rb
+++ b/spec/unit/aql_spec.rb
@@ -1,0 +1,26 @@
+require "spec_helper"
+
+module Artifactory::AQL
+  describe "ItemQueryBuilder" do
+    # it "raises error if nothing provided" do
+    #   builder = ItemQueryBuilder.new
+    #   expect(builder.query).to raise_error(RuntimeError)
+    # end
+
+    it "takes a single criteria" do
+      builder = ItemQueryBuilder.new
+      builder.with_criteria("build.name", :equals, "artifactory")
+      expect(builder.query).to eq("items.find({\"@build.name\":{\"$eq\":\"artifactory\"}})")
+    end
+
+    # it "takes a several criteria" do
+    #   builder = ItemQueryBuilder.new
+    #   expect(builder.query).to eq("")
+    # end
+
+    # it "takes a criteria and a compound criteria" do
+    #   builder = ItemQueryBuilder.new
+    #   expect(builder.query).to eq("")
+    # end
+  end
+end

--- a/spec/unit/aql_spec.rb
+++ b/spec/unit/aql_spec.rb
@@ -2,25 +2,31 @@ require "spec_helper"
 
 module Artifactory::AQL
   describe "ItemQueryBuilder" do
-    # it "raises error if nothing provided" do
-    #   builder = ItemQueryBuilder.new
-    #   expect(builder.query).to raise_error(RuntimeError)
-    # end
-
     it "takes a single criteria" do
       builder = ItemQueryBuilder.new
-      builder.with_criteria("build.name", :equals, "artifactory")
+      builder.with_criteria(["@build.name", :eq, "artifactory"])
       expect(builder.query).to eq("items.find({\"@build.name\":{\"$eq\":\"artifactory\"}})")
     end
 
-    # it "takes a several criteria" do
-    #   builder = ItemQueryBuilder.new
-    #   expect(builder.query).to eq("")
-    # end
+    it "takes a several criteria" do
+      builder = ItemQueryBuilder.new
+      builder.with_criteria(["@build.name", :eq, "artifactory"])
+      builder.with_criteria(["@build.number", :ne, "123"])
+      expect(builder.query).to eq("items.find({\"@build.name\":{\"$eq\":\"artifactory\"},\"@build.number\":{\"$ne\":\"123\"}})")
+    end
 
-    # it "takes a criteria and a compound criteria" do
-    #   builder = ItemQueryBuilder.new
-    #   expect(builder.query).to eq("")
-    # end
+    it "takes a criteria and a compound criteria" do
+      builder = ItemQueryBuilder.new
+      builder.with_criteria(["build.name", :eq, "artifactory"])
+      builder.with_compound_criteria(
+        [:or, 
+          [
+            ["artifact.module.build.param", :eq, "maven+example"], 
+            ["artifact.module.build.number", :ne, "123"]
+          ]
+        ])
+      expected = "items.find({\"build.name\":{\"$eq\":\"artifactory\"},\"$or\":[{\"artifact.module.build.param\":{\"$eq\":\"maven+example\"}},{\"artifact.module.build.number\":{\"$ne\":\"123\"}}]})"
+      expect(builder.query).to eq(expected)
+    end
   end
 end

--- a/spec/unit/resources/artifact_spec.rb
+++ b/spec/unit/resources/artifact_spec.rb
@@ -9,6 +9,7 @@ module Artifactory
     before(:each) do
       allow(Artifactory).to receive(:client).and_return(client)
       allow(client).to receive(:get).and_return(response) if defined?(response)
+      allow(client).to receive(:post).and_return(response) if defined?(response)
     end
 
     describe ".search" do
@@ -159,6 +160,19 @@ module Artifactory
         subject.upload_from_archive("libs-release-local", "/remote/path")
       end
 
+    end
+
+    describe ".aql_search" do
+      let(:response) { { "results" => [] } }
+
+      it "calls /api/search/aql" do
+        expect(client).to receive(:post).with("/api/search/aql", {}).once
+        described_class.aql_search
+      end
+
+      it "returns an array of objects" do
+        expect(described_class.aql_search).to be_a(Array)
+      end
     end
 
     describe ".gavc_search" do


### PR DESCRIPTION
### If applied, this pull request will...
- [x] add aql endpoint
- [x] add integration tests
- [x] add unit tests
- [x] **STRETCH**: add a builder for the aql to make it easier to use (so far the new endpoint just takes a string)
  - [x] Did this with some recursion, not full (if deeper compound is required, can just pass a string)

### Resources
* [AQL Definition](https://www.jfrog.com/confluence/display/JFROG/Artifactory+Query+Language)