### PR TITLE
SRE-4646 - Change content type for AQL to text/plain

### DIFF
--- a/lib/artifactory/resources/artifact.rb
+++ b/lib/artifactory/resources/artifact.rb
@@ -81,7 +81,7 @@ module Artifactory
         client = extract_client!(options)
         params = Util.slice(options, :aql)
         headers ||= {
-          "Content-Type" => "plain/text",
+          "Content-Type" => "text/plain",
         }
 
         client.post("/api/search/aql", params[:aql], headers)["results"].map do |artifact|


### PR DESCRIPTION
This PR changes the AQL `Content-Type` from `plain/text` to `text/plain`.

This content type is documented in the API here: https://www.jfrog.com/confluence/display/JFROG/Artifactory+REST+API#ArtifactoryRESTAPI-ArtifactoryQueryLanguage(AQL)